### PR TITLE
Feat: [#8] 로그인 페이지 모바일 데스크톱으로 분할

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,49 +1,7 @@
-import React from "react";
-import TextInput from "../../components/ui/button/TextInput"
-import { NaverLoginButton } from "../../components/ui/button/NaverLoginButton";
-import { KakaoLoginButton } from "../../components/ui/button/KakaoLoginButton";
-import { FaUser, FaLock } from "react-icons/fa";
-import  { Button } from "../../components/ui/button/index";
-import Logo from "../../assets/Logo";
+import React from 'react'
+import Login from '@/components/auth/login'
+import '@/styles/globals.css'
 
 export default function LoginPage() {
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-white">
-      <div className="flex flex-col items-center gap-6">
-        <div className="flex flex-col items-center gap-2">
-        <div>
-            <Logo width={30} height={30} className="mb-0" />
-        </div>  
-          <span className="text-[20px] font-bold text-[#7B61FF]">Fact Seeker</span>
-        </div>
-        
-        <h2 className="text-xl font-bold text-black mt-4">로그인</h2>
-
-        <div className="flex flex-col gap-5 mt-2">
-          <TextInput placeholder="아이디" iconLeft={<FaUser />} />
-          <TextInput type="password" placeholder="비밀번호" iconLeft={<FaLock />} />
-        </div>
-
-        <Button color="black" size="lg" fullWidth>
-            로그인
-        </Button>
-
-        
-        <div className="flex items-center justify-center text-xs text-[#626262] font-[Pretendard] gap-2">
-            <span className="cursor-pointer">회원가입</span>
-            <span className="text-[#C4C4C4]">|</span>
-            <span className="cursor-pointer">아이디 찾기</span>
-            <span className="text-[#C4C4C4]">|</span>
-            <span className="cursor-pointer">비밀번호 찾기</span>
-        </div>
-
-        <div className="w-96 h-[1px] bg-[#E0E0E0] mt-[-4px]" />
-        <div className="mt-4 text-black text-sm">소셜 로그인</div>
-        <div className="flex flex-col gap-4 items-center">
-            <NaverLoginButton className="w-96 h-12 text-base" />
-            <KakaoLoginButton className="w-96 h-12 text-base" />
-        </div>
-      </div>
-    </div>
-  );
+  return <Login />
 }

--- a/src/components/auth/login/DesktopLogin.tsx
+++ b/src/components/auth/login/DesktopLogin.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+import LoginForm from './LoginForm'
+
+export default function DesktopLogin() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-[var(--background)]">
+      <div className="w-full max-w-md p-8 bg-[var(--white)] rounded-xl shadow-lg">
+        <LoginForm />
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/login/LoginForm.tsx
+++ b/src/components/auth/login/LoginForm.tsx
@@ -1,0 +1,60 @@
+'use client'
+import React from 'react'
+import Logo                 from '@/assets/Logo'
+import TextInput            from '@/components/ui/button/TextInput'
+import { Button }           from '@/components/ui/button/index'
+import { NaverLoginButton } from '@/components/ui/button/NaverLoginButton'
+import { KakaoLoginButton } from '@/components/ui/button/KakaoLoginButton'
+import { FaUser, FaLock }   from 'react-icons/fa'
+
+export default function LoginForm() {
+  return (
+    <div className="flex flex-col items-center gap-6 w-full text-[var(--foreground)]">
+      <div className="flex flex-col items-center gap-2">
+        <Logo width={30} height={30} />
+        <span className="text-2xl font-bold text-[var(--primary-normal)]">
+          Fact Seeker
+        </span>
+      </div>
+
+      <h2 className="text-xl font-bold text-[var(--black-normal)]">로그인</h2>
+      <div className="flex flex-col gap-4 w-full">
+        <TextInput
+          placeholder="아이디"
+          iconLeft={<FaUser />}
+          className="bg-[var(--gray-light)] text-[var(--foreground)]"
+        />
+        <TextInput
+          type="password"
+          placeholder="비밀번호"
+          iconLeft={<FaLock />}
+          className="bg-[var(--gray-light)] text-[var(--foreground)]"
+        />
+      </div>
+
+      <Button
+        fullWidth
+        size="lg"
+        color='black'
+      >
+        로그인
+      </Button>
+
+      <div className="flex items-center justify-center text-xs text-[var(--black-normal)] gap-2">
+        <span className="cursor-pointer">회원가입</span>
+        <span>|</span>
+        <span className="cursor-pointer">아이디 찾기</span>
+        <span>|</span>
+        <span className="cursor-pointer">비밀번호 찾기</span>
+      </div>
+
+      <div className="w-full h-px bg-[var(--gray-normal)]" />
+
+      <p className="mt-4 text-sm text-[var(--foreground)]">소셜 로그인</p>
+      <div className="flex flex-col gap-3 w-full">
+        <NaverLoginButton className="w-full h-12 text-base" />
+        <KakaoLoginButton className="w-full h-12 text-base" />
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/login/MobileLogin.tsx
+++ b/src/components/auth/login/MobileLogin.tsx
@@ -1,0 +1,13 @@
+'use client'
+import React from 'react'
+import LoginForm from './LoginForm'
+
+export default function MobileLogin() {
+  return (
+    <div className="flex items-center justify-center min-h-screen px-4 bg-[var(--background)]">
+      <div className="w-full max-w-xs p-6 bg-[var(--white)] rounded-lg shadow">
+        <LoginForm />
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/login/index.tsx
+++ b/src/components/auth/login/index.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { useEffect, useState } from 'react'
+import DesktopLogin from './DesktopLogin'
+import MobileLogin  from './MobileLogin'
+
+export default function Login() {
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia('(max-width: 640px)')
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    setIsMobile(mql.matches)
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return isMobile ? <MobileLogin /> : <DesktopLogin />
+}


### PR DESCRIPTION

<img width="442" height="646" alt="image" src="https://github.com/user-attachments/assets/76efbe3a-932b-4c66-82dc-2893f0b74eeb" />


로그인 페이지 모바일, 데스크톱 버전으로 분할 했습니다. 방식은 컴포넌트 폴더 안에 Auth 폴더를 만들고 그 안에 모바일, 데스크톱 컴포넌트 를 만들고 index에서 삼향 연산자를 사용해서 모바일로 열면 모바일 버전이, 데스크톱으로 열면 데스크톱 버전이 렌더링 되도록 바꾸었습니다!