### PR TITLE
Feat: 정치인 분석 화면 로딩 분할 비동기처리

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,18 @@
 import type { NextConfig } from 'next';
 
+function pickApiBase() {
+  // 여러 이름을 지원 + 프로토콜 보정 + 트레일링 슬래시 제거
+  const raw =
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    process.env.NEXT_PUBLIC_API_SERVER_URL ||
+    process.env.API_SERVER_URL ||
+    process.env.API_BASE_URL;
+
+  if (!raw) return undefined;
+  const withProto = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  return withProto.replace(/\/+$/, '');
+}
+
 const nextConfig: NextConfig = {
   images: {
     domains: ['yt3.ggpht.com', 'i.ytimg.com', 'img.youtube.com'],
@@ -13,11 +26,15 @@ const nextConfig: NextConfig = {
   },
 
   async rewrites() {
+    const base = pickApiBase();
+    if (!base) {
+      console.warn('[rewrites] API base URL not set. Skipping /api proxy.');
+      return []; // env 없으면 rewrite 자체 생략 → build 에러 방지
+    }
     return [
       {
         source: '/api/:path*',
-        // 실제 백엔드 주소 환경변수로 주입
-        destination: `${process.env.API_BASE_URL}/api/:path*`,
+        destination: `${base}/api/:path*`,
       },
     ];
   },

--- a/src/app/(default)/politician/[name]/PoliticianDetailClient.tsx
+++ b/src/app/(default)/politician/[name]/PoliticianDetailClient.tsx
@@ -31,14 +31,8 @@ const pickLatest = (rows: ScoreRow[] = []) =>
     const bd = dateKey(best.analysisDate);
     if (nd > bd) return cur;
     if (nd === bd) {
-      const ns = (cur.overallScore ??
-        cur.trustScore ??
-        cur.totalScore ??
-        0) as number;
-      const bs = (best.overallScore ??
-        best.trustScore ??
-        best.totalScore ??
-        0) as number;
+      const ns = (cur.overallScore ?? cur.trustScore ?? cur.totalScore ?? 0) as number;
+      const bs = (best.overallScore ?? best.trustScore ?? best.totalScore ?? 0) as number;
       return ns >= bs ? cur : best;
     }
     return best;
@@ -57,7 +51,6 @@ const domainLabel = (url = '') => {
   }
 };
 
-// 뉴스 → VideoItem
 function mapNewsToVideoItems(
   news: { title: string; link: string; pubDate?: string }[],
 ): VideoItem[] {
@@ -67,7 +60,6 @@ function mapNewsToVideoItems(
     link: n.link,
     channelName: domainLabel(n.link),
     publishedAt: n.pubDate,
-    // thumbnailUrl: 나중에 주입
   })) as unknown as VideoItem[];
 }
 
@@ -111,7 +103,9 @@ async function enrichNewsThumbnails(items: VideoItem[], signal?: AbortSignal) {
 }
 
 export default function PoliticianDetailClient({ name }: { name: string }) {
-  const [loading, setLoading] = useState(true);
+  const [loadingCard, setLoadingCard] = useState(true);
+  const [loadingNews, setLoadingNews] = useState(true);
+  const [loadingVideos, setLoadingVideos] = useState(true);
 
   const [politician, setPolitician] = useState<{
     name: string;
@@ -146,8 +140,7 @@ export default function PoliticianDetailClient({ name }: { name: string }) {
 
     (async () => {
       try {
-        setLoading(true);
-
+        setLoadingCard(true);
         const scoresResp: any = await (searchPoliticianScoresByName as any)(
           name,
           0,
@@ -157,10 +150,10 @@ export default function PoliticianDetailClient({ name }: { name: string }) {
         const list: ScoreRow[] = Array.isArray(payload)
           ? payload
           : (payload.politicians ??
-            payload.results ??
-            payload.items ??
-            payload.data ??
-            []);
+              payload.results ??
+              payload.items ??
+              payload.data ??
+              []);
         const picked = pickLatest(list) || {};
 
         const overall = Math.round(
@@ -180,32 +173,41 @@ export default function PoliticianDetailClient({ name }: { name: string }) {
             stats: { fact: overall, gpt, claude: gemini },
           });
         }
+      } catch (e) {
+        console.warn('[scores] load failed:', e);
+      } finally {
+        if (alive) setLoadingCard(false);
+      }
+    })();
 
-        const [newsRes, ytRes] = await Promise.allSettled([
-          searchNewsByKeyword(name, {
-            sort: 'date',
-            display: 10,
-            signal: ac.signal,
-          }),
-          searchYoutubeByKeyword(name, { signal: ac.signal }),
-        ]);
+    (async () => {
+      try {
+        setLoadingNews(true);
+        const newsRes = await searchNewsByKeyword(name, {
+          sort: 'date',
+          display: 10,
+          signal: ac.signal,
+        });
+        const base = mapNewsToVideoItems(newsRes.items || []);
+        const withThumbs = await enrichNewsThumbnails(base, ac.signal);
+        if (alive) setNews(withThumbs);
+      } catch (e) {
+        if (alive) setNews([]);
+        console.warn('[news] load failed:', e);
+      } finally {
+        if (alive) setLoadingNews(false);
+      }
+    })();
 
-        if (!alive) return;
-
-        if (newsRes.status === 'fulfilled') {
-          const base = mapNewsToVideoItems(newsRes.value.items || []);
-          const withThumbs = await enrichNewsThumbnails(base, ac.signal);
-          setNews(withThumbs);
-        } else {
-          setNews([]);
-          console.warn('[news] load failed:', newsRes.reason);
-        }
-
-        if (ytRes.status === 'fulfilled') {
-          const raw = ytRes.value.items || [];
+    (async () => {
+      try {
+        setLoadingVideos(true);
+        const ytRes = await searchYoutubeByKeyword(name, { signal: ac.signal });
+        const raw = ytRes.items || [];
+        if (alive)
           setVideos(
             mapYoutubeToVideoItems(
-              raw.map((r) => ({
+              raw.map((r: any) => ({
                 url: r.url,
                 title: r.title,
                 thumbnailUrl: r.thumbnailUrl,
@@ -213,30 +215,19 @@ export default function PoliticianDetailClient({ name }: { name: string }) {
               })),
             ),
           );
-        } else {
-          setVideos([]);
-          console.warn('[youtube] load failed:', ytRes.reason);
-        }
       } catch (e) {
-        console.error('[politician detail] fetch error', e);
+        if (alive) setVideos([]);
+        console.warn('[youtube] load failed:', e);
       } finally {
-        if (alive) setLoading(false);
+        if (alive) setLoadingVideos(false);
       }
     })();
 
-    return () => {
+  return () => {
       alive = false;
       ac.abort();
     };
   }, [name]);
-
-  if (loading) {
-    return (
-      <div className="w-full max-w-6xl px-4 py-6 text-center text-sm text-gray-500 md:px-6">
-        불러오는 중…
-      </div>
-    );
-  }
 
   return (
     <>
@@ -246,6 +237,9 @@ export default function PoliticianDetailClient({ name }: { name: string }) {
           videos={videos}
           news={news}
           updatedAt={updatedAt}
+          loadingCard={loadingCard}
+          loadingNews={loadingNews}
+          loadingVideos={loadingVideos}
         />
       </div>
       <div className="w-full md:hidden">
@@ -254,6 +248,9 @@ export default function PoliticianDetailClient({ name }: { name: string }) {
           videos={videos}
           news={news}
           updatedAt={updatedAt}
+          loadingCard={loadingCard}
+          loadingNews={loadingNews}
+          loadingVideos={loadingVideos}
         />
       </div>
     </>

--- a/src/components/politician/organisms/PoliticianDetailDesktop.tsx
+++ b/src/components/politician/organisms/PoliticianDetailDesktop.tsx
@@ -27,6 +27,9 @@ interface Props {
   videos: VideoItem[];
   news?: VideoItem[];
   updatedAt?: string;
+  loadingCard?: boolean;
+  loadingNews?: boolean;
+  loadingVideos?: boolean;
 }
 
 export default function PoliticianDetailDesktop({
@@ -34,6 +37,9 @@ export default function PoliticianDetailDesktop({
   videos,
   news,
   updatedAt,
+  loadingCard,
+  loadingNews,
+  loadingVideos,
 }: Props) {
   const imgSrc = politician.img ?? politician.figureImg ?? '';
   const [tab, setTab] = useState<'news' | 'youtube'>('youtube');
@@ -69,22 +75,28 @@ export default function PoliticianDetailDesktop({
               선택 인물
             </p>
 
-            <div className="mb-5 flex items-center justify-center gap-4">
-              <div className="relative h-20 w-20 shrink-0">
-                <PoliticianImage
-                  src={imgSrc}
-                  alt={`${politician.name} 이미지`}
-                />
+            {loadingCard ? (
+              <div className="mb-5 flex h-20 items-center justify-center text-sm text-gray-500">
+                불러오는 중…
               </div>
-              <div className="min-w-0">
-                <p className="text-black-normal truncate text-lg font-bold">
-                  {maskTail(politician.name, 1)}
-                </p>
-                <p className="text-black-normal mt-1 truncate text-sm">
-                  {politician.party}
-                </p>
+            ) : (
+              <div className="mb-5 flex items-center justify-center gap-4">
+                <div className="relative h-20 w-20 shrink-0">
+                  <PoliticianImage
+                    src={imgSrc}
+                    alt={`${politician.name} 이미지`}
+                  />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-black-normal truncate text-lg font-bold">
+                    {maskTail(politician.name, 1)}
+                  </p>
+                  <p className="text-black-normal mt-1 truncate text-sm">
+                    {politician.party}
+                  </p>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className="text-black-normal mb-6 py-3 text-center text-sm">
               <span className="font-medium">누적 신뢰도: </span>
@@ -116,7 +128,11 @@ export default function PoliticianDetailDesktop({
             {updatedAt && <p className="text-xs text-gray-500">{updatedAt}</p>}
           </div>
 
-          {list.length ? (
+          {(tab === 'youtube' ? loadingVideos : loadingNews) ? (
+            <div className="flex h-[320px] items-center justify-center text-sm text-gray-500">
+              {tab === 'youtube' ? '영상 불러오는 중…' : '뉴스 불러오는 중…'}
+            </div>
+          ) : list.length ? (
             <div>
               <Swiper
                 className="desktop-video-swiper"

--- a/src/components/politician/organisms/PoliticianDetailMobile.tsx
+++ b/src/components/politician/organisms/PoliticianDetailMobile.tsx
@@ -1,16 +1,12 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import Link from 'next/link';
 import PoliticianImage from '@/components/ui/profile/PoliticianImage';
+import VideoRow from '@/components/politician/molecules/VideoRow';
 import SwitchButton from '@/components/ui/button/SwitchButton';
-import VideoCard from '@/components/politician/molecules/VideoCard';
 import type { VideoItem } from '@/constants/videoList';
 import { maskTail } from '@/utils/maskTail';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Navigation, Pagination } from 'swiper/modules';
-import 'swiper/css';
-import 'swiper/css/navigation';
-import 'swiper/css/pagination';
 
 type Stat = { fact: number; gpt: number; claude: number };
 type Politician = {
@@ -26,21 +22,26 @@ interface Props {
   videos: VideoItem[];
   news?: VideoItem[];
   updatedAt?: string;
+  loadingCard?: boolean;
+  loadingNews?: boolean;
+  loadingVideos?: boolean;
 }
 
 export default function PoliticianDetailMobile({
   politician,
   videos,
-  news = [],
+  news,
   updatedAt,
+  loadingCard,
+  loadingNews,
+  loadingVideos,
 }: Props) {
   const imgSrc = politician.img ?? politician.figureImg ?? '';
   const [tab, setTab] = useState<'news' | 'youtube'>('youtube');
 
   const pageSize = 5;
-  const list = tab === 'youtube' ? videos : news;
-
-  const slides: VideoItem[][] = useMemo(() => {
+  const list = tab === 'youtube' ? videos : (news ?? []);
+  const pages: VideoItem[][] = useMemo(() => {
     const chunks: VideoItem[][] = [];
     for (let i = 0; i < list.length; i += pageSize) {
       chunks.push(list.slice(i, i + pageSize));
@@ -51,114 +52,75 @@ export default function PoliticianDetailMobile({
   const cumulative = `${Math.round(politician.stats.fact ?? 0)}%`;
 
   return (
-    <section className="mx-auto w-full rounded-2xl bg-white p-4">
-      <div className="mb-4 rounded-2xl border border-gray-200 p-4">
+    <section className="mx-auto mt-4 w-full rounded-2xl border border-gray-200 bg-white px-4 py-4">
+      <div className="mb-3">
+        <Link
+          href="/politician"
+          className="text-sm font-medium text-gray-500 hover:underline"
+        >
+          {'< 다시 선택'}
+        </Link>
+      </div>
+
+      <div className="my-3 rounded-2xl border border-gray-200 p-4">
         <p className="text-black-normal mb-3 text-center text-lg font-extrabold">
           선택 인물
         </p>
 
-        <div className="mb-4 flex items-center justify-center gap-3">
-          <div className="relative h-16 w-16 shrink-0">
-            <PoliticianImage src={imgSrc} alt={`${politician.name} 이미지`} />
+        {loadingCard ? (
+          <div className="mb-4 flex h-16 items-center justify-center text-sm text-gray-500">
+            불러오는 중…
           </div>
-          <div className="min-w-0">
-            <p className="text-black-normal truncate text-base font-bold">
-              {maskTail(politician.name, 1)}
-            </p>
-            <p className="text-black-normal mt-0.5 truncate text-xs">
-              {politician.party}
-            </p>
+        ) : (
+          <div className="mb-4 flex items-center justify-center gap-3">
+            <div className="relative h-16 w-16 shrink-0">
+              <PoliticianImage src={imgSrc} alt={`${politician.name} 이미지`} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-black-normal truncate text-base font-bold">
+                {maskTail(politician.name, 1)}
+              </p>
+              <p className="text-black-normal mt-1 truncate text-xs">
+                {politician.party}
+              </p>
+            </div>
           </div>
-        </div>
+        )}
 
-        <div className="text-black-normal py-2 text-center text-xs">
+        <div className="text-black-normal py-2 text-center text-sm">
           <span className="font-medium">누적 신뢰도: </span>
           <span className="font-bold">{cumulative}</span>
         </div>
+
+        {updatedAt && (
+          <div className="mt-1 text-center text-xs text-gray-500">{updatedAt}</div>
+        )}
       </div>
 
-      <div className="mb-3">
-        <SwitchButton
-          value={tab}
-          onChange={(val) => setTab(val as 'news' | 'youtube')}
-          options={[
-            { label: '뉴스기사 모아보기', value: 'news' },
-            { label: '유튜브 모아보기', value: 'youtube' },
-          ]}
-          className="flex w-full justify-center gap-4"
-        />
-      </div>
+      <SwitchButton
+        value={tab}
+        onChange={(val) => setTab(val as 'news' | 'youtube')}
+        options={[
+          { label: '뉴스기사 모아보기', value: 'news' },
+          { label: '유튜브 모아보기', value: 'youtube' },
+        ]}
+        className="mb-3 flex w-full justify-center gap-2"
+      />
 
-      <div className="flex items-center justify-end border-b border-gray-200 px-2 py-3">
-        {updatedAt && <p className="text-[11px] text-gray-500">{updatedAt}</p>}
-      </div>
-
-      {list.length ? (
-        <div className="pt-2">
-          <Swiper
-            className="mobile-video-swiper"
-            modules={[Navigation, Pagination]}
-            navigation
-            pagination={{ clickable: true }}
-            slidesPerView={1}
-            spaceBetween={8}
-          >
-            {slides.map((chunk, i) => (
-              <SwiperSlide key={i}>
-                <div className="px-2">
-                  {chunk.map((v) => (
-                    <VideoCard key={v.id} video={v} compact />
-                  ))}
-                </div>
-              </SwiperSlide>
-            ))}
-          </Swiper>
-
-          <style jsx global>{`
-            .mobile-video-swiper {
-              padding-bottom: 16px;
-            }
-            .mobile-video-swiper .swiper-pagination {
-              position: static !important;
-              margin-top: 6px;
-            }
-            .mobile-video-swiper .swiper-pagination-bullet {
-              width: 6px;
-              height: 6px;
-              background: #d1d5db;
-              opacity: 1;
-            }
-            .mobile-video-swiper .swiper-pagination-bullet-active {
-              background: #111827;
-            }
-            .mobile-video-swiper .swiper-button-prev,
-            .mobile-video-swiper .swiper-button-next {
-              color: #374151;
-              width: 26px;
-              height: 26px;
-              top: auto;
-              bottom: 0;
-            }
-            .mobile-video-swiper .swiper-button-prev {
-              left: 12px;
-            }
-            .mobile-video-swiper .swiper-button-next {
-              right: 12px;
-            }
-            .mobile-video-swiper .swiper-button-prev:after,
-            .mobile-video-swiper .swiper-button-next:after {
-              font-size: 16px;
-            }
-            .mobile-video-swiper .swiper-button-disabled {
-              opacity: 0.35;
-            }
-          `}</style>
+      {/* 리스트 영역 */}
+      {(tab === 'youtube' ? loadingVideos : loadingNews) ? (
+        <div className="flex h-[280px] items-center justify-center text-sm text-gray-500">
+          {tab === 'youtube' ? '영상 불러오는 중…' : '뉴스 불러오는 중…'}
+        </div>
+      ) : list.length ? (
+        <div className="px-2">
+          {pages[0].map((v) => (
+            <VideoRow key={v.id} video={v} />
+          ))}
         </div>
       ) : (
-        <div className="flex h-[260px] items-center justify-center text-xs text-gray-500">
-          {tab === 'youtube'
-            ? '영상 데이터가 없습니다.'
-            : '뉴스 데이터가 없습니다.'}
+        <div className="flex h-[280px] items-center justify-center text-sm text-gray-500">
+          {tab === 'youtube' ? '영상 데이터가 없습니다.' : '뉴스 데이터가 없습니다.'}
         </div>
       )}
     </section>


### PR DESCRIPTION
요청하신 대로 로딩화면 3구성으로 나눠서 왼쪽 정치인 카드, 유튜브 영상, 기사 세개 따로 로딩 분할 하여 업로드 했습니다! vercel 들어가서 해당 브랜치 들어가시면 확인 가능합니다!

- closed #61 