### PR TITLE
Refactor: 소셜 로그인 페이지에서 api 로직 분리

### DIFF
--- a/src/apis/auth/social-login.ts
+++ b/src/apis/auth/social-login.ts
@@ -15,15 +15,26 @@ export type ApiSuccess<T> = { success: true; message?: string; data: T };
 export type ApiFail = { success: false; message?: string };
 
 export function extractTokenPayload(d: unknown): TokenPayload | null {
-  const maybe: any = (d as any)?.data ?? d;
-  if (maybe && typeof maybe.accessToken === 'string' && typeof maybe.refreshToken === 'string') {
+  if (!d || typeof d !== 'object') return null;
+  const hasDataField = 'data' in d && typeof (d as { data?: unknown }).data === 'object';
+  const maybe = hasDataField ? (d as { data: object }).data : d;
+
+  const isTokenPayload = (obj: unknown): obj is TokenPayload => {
+    if (!obj || typeof obj !== 'object') return false;
+    const o = obj as Record<string, unknown>;
+    return typeof o.accessToken === 'string' && typeof o.refreshToken === 'string';
+  };
+
+  if (isTokenPayload(maybe)) {
+    const o = maybe as TokenPayload;
     return {
-      accessToken: maybe.accessToken,
-      refreshToken: maybe.refreshToken,
-      tokenType: typeof maybe.tokenType === 'string' ? maybe.tokenType : 'Bearer',
-      expiresIn: typeof maybe.expiresIn === 'number' ? maybe.expiresIn : undefined,
+      accessToken: o.accessToken,
+      refreshToken: o.refreshToken,
+      tokenType: o.tokenType ?? 'Bearer',
+      expiresIn: o.expiresIn,
     };
   }
+
   return null;
 }
 

--- a/src/apis/auth/social-login.ts
+++ b/src/apis/auth/social-login.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import apiClient from '@/apis/apiClient';
+
+export type VerifyRes = { name?: string; age?: string; age_range?: string };
+
+export type TokenPayload = {
+  accessToken: string;
+  refreshToken: string;
+  tokenType?: string;
+  expiresIn?: number;
+};
+
+export type ApiSuccess<T> = { success: true; message?: string; data: T };
+export type ApiFail = { success: false; message?: string };
+
+export function extractTokenPayload(d: unknown): TokenPayload | null {
+  const maybe: any = (d as any)?.data ?? d;
+  if (maybe && typeof maybe.accessToken === 'string' && typeof maybe.refreshToken === 'string') {
+    return {
+      accessToken: maybe.accessToken,
+      refreshToken: maybe.refreshToken,
+      tokenType: typeof maybe.tokenType === 'string' ? maybe.tokenType : 'Bearer',
+      expiresIn: typeof maybe.expiresIn === 'number' ? maybe.expiresIn : undefined,
+    };
+  }
+  return null;
+}
+
+export async function verifySocial(token: string) {
+  const { data } = await apiClient.get<VerifyRes>('/auth/social/verify', {
+    params: { token },
+  });
+  return data;
+}
+
+export type CompleteReq = {
+  tempToken: string;
+  fullname?: string;
+  gender?: string;
+  ageRange?: string;
+  phone?: string;
+  email?: string;
+};
+
+export async function completeSocial(payload: CompleteReq) {
+  const res = await apiClient.post<ApiSuccess<TokenPayload> | TokenPayload | ApiFail>(
+    '/social/complete',
+    payload,
+  );
+
+  const tokens = extractTokenPayload(res.data);
+  return { raw: res.data, tokens };
+}


### PR DESCRIPTION
- 소셜 로그인 페이지 내의 api 로직을 분리하였습니다.
- any 타입을 제거했습니다.